### PR TITLE
New knox configuration scripts for existing grafana installation

### DIFF
--- a/cod/scripts/README.md
+++ b/cod/scripts/README.md
@@ -18,7 +18,7 @@ This repository contains scripts for COD to install Grafana manually.
 
 
 ## Manual Installation Steps
-1. scp two Files `grafana-install-configure-v2.sh` and `configure-knox-for-grafana.sh` to the gateway node of the COD cluster.
+1. scp two Files `grafana-install-configure-v2.sh` and `configure-knox-for-grafana.sh` [if you are using CDH version 7.2.15 then download `configure-knox-for-grafana7215.sh`] to the gateway node of the COD cluster.
 e.g,
 ```
 scp -i ~/.ssh/odx-developers.pem ./grafana-install-configure-v2.sh cloudbreak@10.80.192.182:
@@ -95,7 +95,9 @@ CGroup: /system.slice/grafana-server.service
 e.g,
 `./configure-knox-for-grafana.sh`
 
-Output of the above command should be as below
+Note: In case you are using CDH version 7.2.15 then please use `./configure-knox-for-grafana7215.sh`
+
+Output of the above command should be similar to
 ```ecmascript 6
 Installing knox service configs for grafana
 Adding GRAFANA service in the cdp-proxy topology

--- a/cod/scripts/configure-knox-for-grafana7215.sh
+++ b/cod/scripts/configure-knox-for-grafana7215.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 Cloudera, Inc. All rights reserved.
+#
+
+cdh_loc="$(find /opt/cloudera/parcels/ -name CDH-* | tail -1)"
+service_loc="$cdh_loc/lib/knox/data/services"
+j2topology_loc="/srv/salt/gateway/config/cm"
+j2topology_orig_file="topology.xml.j2"
+j2topology_backup_file="topology.xml.j2-backup"
+
+topology_loc="/var/lib/knox/cloudbreak_resources/topologies"
+topology_orig_file="cdp-proxy.xml"
+topology_backup_file="cdp-proxy.xml-backup"
+
+host_fqdn=$(hostname --fqdn)
+
+service_xml_str=$(cat <<-END
+<service role="GRAFANACOD" name="grafanacod" version="1.0.0">
+  <metadata>
+     <context>/../../grafanacod/dashboards</context>
+     <description>GRAFANACOD</description>
+     <shortDesc>GRAFANACOD</shortDesc>
+     <type>UI</type>
+  </metadata>
+  <routes>
+    <route path="/grafanacod/"></route>
+    <route path="/grafanacod/**">
+    </route>
+  </routes>
+  <dispatch classname="org.apache.knox.gateway.dispatch.HeaderPreAuthFederationDispatch" />
+</service>
+END
+)
+
+rewrite_xml_str=$(cat <<-END
+<rules>
+  <rule dir="IN" name="GRAFANACOD/grafanacod/root" pattern="*://*:*/**/grafanacod/">
+    <rewrite template="{\$serviceUrl[GRAFANACOD]}/"/>
+  </rule>
+  <rule dir="IN" name="GRAFANACOD/grafanacod/inbound" pattern="*://*:*/**/grafanacod/{path=**}?{**}">
+    <rewrite template="{\$serviceUrl[GRAFANACOD]}/{path=**}?{**}"/>
+  </rule>
+</rules>
+END
+)
+
+if [ -d "$service_loc" ]; then
+  grafana_dir="$service_loc/grafanacod/1.0.0"
+  if [ -d "$grafana_dir" ]; then
+    echo "Directory $grafana_dir already exists, do nothing"
+  else
+    echo "Installing knox service configs for grafana"
+    mkdir -p $grafana_dir
+
+    rewrite_file="rewrite.xml"
+    service_file="service.xml"
+
+    printf "%s" "$service_xml_str" > $grafana_dir/$service_file
+    printf "%s" "$rewrite_xml_str" > $grafana_dir/$rewrite_file
+    chmod 755 -R $grafana_dir/..
+    chown cloudera-scm:cloudera-scm -R $grafana_dir/..
+  fi
+fi
+
+if [ -d $j2topology_loc ]; then
+  if [ -s $j2topology_loc/$j2topology_orig_file ]; then
+    exists=$(grep -c GRAFANACOD $j2topology_loc/$j2topology_orig_file)
+    if [ $exists -gt 0 ]; then
+      echo "GRAFANACOD already exists, do nothing"
+    else
+      echo "Adding GRAFANACOD service in the cdp-proxy topology"
+      mv $j2topology_loc/$j2topology_orig_file $j2topology_loc/$j2topology_backup_file
+
+      sed "\#^</topology>#i\
+          <service>\
+            <role>GRAFANACOD</role>\
+            <url>http://$host_fqdn:3000</url>\
+          </service>\
+          " $j2topology_loc/$j2topology_backup_file > $j2topology_loc/$j2topology_orig_file
+      chmod 644 $j2topology_loc/$j2topology_orig_file
+    fi
+  fi
+fi
+
+if [ -d $topology_loc ]; then
+  if [ -s $topology_loc/$topology_orig_file ]; then
+    exists=$(grep -c GRAFANACOD $topology_loc/$topology_orig_file)
+    if [ $exists -gt 0 ]; then
+      echo "GRAFANACOD already exists, do nothing"
+    else
+      echo "Adding GRAFANACOD service in the cdp-proxy topology in the active directory"
+      mv $topology_loc/$topology_orig_file $topology_loc/$topology_backup_file
+
+      sed "\#^</topology>#i\
+          <service>\
+            <role>GRAFANACOD</role>\
+            <url>http://$host_fqdn:3000</url>\
+          </service>\
+          " $topology_loc/$topology_backup_file > $topology_loc/$topology_orig_file
+      chmod 644 $topology_loc/$topology_orig_file
+    fi
+  fi
+fi


### PR DESCRIPTION
In 7215 we observe that grafana is part of the knox library, for those cases we need to use this script to configure grafana on knox